### PR TITLE
Update binary name to match the new version

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-exec /bin/agent                                             \
+exec /bin/grafana-agent                                     \
   --config.file=/etc/agent/agent.yaml                       \
   --metrics.wal-directory=/etc/agent/data                   \
   --config.expand-env                                       \


### PR DESCRIPTION
See https://github.com/grafana/agent/commit/cbbf287e4183e2dcce024027a040857ed5412369

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The image does not work as the latest specified image (`grafana/agent`) does not have the `/bin/agent` binary anymore.
Please link any relevant issues here.

## What is the new behavior?

The new binary `/bin/grafana-agent` is used instead in the run.sh script.
